### PR TITLE
23 feat 보호자 일별 조회 보호자 감정별 감정 모아보기

### DIFF
--- a/src/main/java/com/todai/BE/controller/UserController.java
+++ b/src/main/java/com/todai/BE/controller/UserController.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.Year;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.UUID;
@@ -113,5 +114,13 @@ public class UserController {
     }
 
     @PostMapping("/sharing/{yearMonth}/{emotion_index}")
-    public CommonResponseDto<?> getTarget
+    public CommonResponseDto<?> getTargetEmotionSummary(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable("yearMonth")
+            @DateTimeFormat(pattern = "yyyy-MM")YearMonth yearMonth,
+            @PathVariable("emotion_index")Long emotionIndex,
+            @RequestBody TargetEmotionRequestDTO requestDTO
+            ) {
+        return CommonResponseDto.ok(guardianService.getTargetEmotionSummary(user.getUserId(), yearMonth, emotionIndex, requestDTO));
+    }
 }

--- a/src/main/java/com/todai/BE/controller/UserController.java
+++ b/src/main/java/com/todai/BE/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.UUID;
@@ -101,9 +102,16 @@ public class UserController {
     }
 
 
+    @PostMapping("/sharing/{date}")
+    public CommonResponseDto<?> getTargetDayEmotion(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable("date")
+            @DateTimeFormat(pattern = "yyyy-MM-dd")LocalDate date,
+            @RequestBody TargetEmotionRequestDTO requestDTO
+            ) {
+        return CommonResponseDto.ok(guardianService.getTargetDayEmotion(user.getUserId(), date, requestDTO));
+    }
 
-
-
-
-
+    @PostMapping("/sharing/{yearMonth}/{emotion_index}")
+    public CommonResponseDto<?> getTarget
 }

--- a/src/main/java/com/todai/BE/dto/response/diary/EmotionSummaryResponseDto.java
+++ b/src/main/java/com/todai/BE/dto/response/diary/EmotionSummaryResponseDto.java
@@ -1,0 +1,8 @@
+package com.todai.BE.dto.response.diary;
+
+public record EmotionSummaryResponseDto(
+        String date,
+        String emotion,
+        String summary
+) {
+}

--- a/src/main/java/com/todai/BE/service/DiaryService.java
+++ b/src/main/java/com/todai/BE/service/DiaryService.java
@@ -206,5 +206,4 @@ public class DiaryService {
                 .collect(Collectors.toList());
     }
 
-
 }

--- a/src/main/java/com/todai/BE/service/GuardianService.java
+++ b/src/main/java/com/todai/BE/service/GuardianService.java
@@ -4,6 +4,7 @@ import com.todai.BE.common.exception.CustomException;
 import com.todai.BE.common.exception.ErrorCode;
 import com.todai.BE.dto.request.user.TargetEmotionRequestDTO;
 import com.todai.BE.dto.response.diary.EmotionResponseDto;
+import com.todai.BE.dto.response.diary.EmotionSummaryResponseDto;
 import com.todai.BE.dto.response.diary.EmotionsResponseDto;
 import com.todai.BE.dto.response.user.TargetEmotionsResponseDTO;
 import com.todai.BE.entity.Diary;
@@ -18,9 +19,7 @@ import com.todai.BE.entity.User;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -120,5 +119,46 @@ public class GuardianService {
         String label = mapToLabel(emotion);
 
         return new EmotionResponseDto(label, emotion, diary.getSummary(), diary.isMarking());
+    }
+
+    public List<EmotionSummaryResponseDto> getTargetEmotionSummary(UUID userId, YearMonth yearMonth, Long emotionIndex, TargetEmotionRequestDTO requestDTO) {
+        //타겟 사용자 아이디
+        UUID targetId = requestDTO.targetId();
+
+        //타겟 유저 존재 여부 검증
+        User owner = userRepository.findById(targetId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TARGET));
+
+        //연동 관계 존재 여부 검증
+        Sharing sharing = sharingRepository.findByOwner_UserIdAndSharedWith_UserIdAndShareState(targetId, userId, ShareState.MATCHED)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SHARING));
+
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end   = yearMonth.atEndOfMonth();
+
+        List<Diary> diaries = diaryRepository.findAllByUser_UserIdAndDateBetween(targetId, start, end);
+
+        return diaries.stream()
+                .map(diary -> {
+                    List<Double> em = diary.getEmotion();
+
+                    int maxIndex = -1;
+                    double maxValue = Double.NEGATIVE_INFINITY;
+                    for (int i = 0; i < em.size(); i++) {
+                        if (em.get(i) != null && !em.get(i).isNaN() && em.get(i) > maxValue) {
+                            maxValue = em.get(i);
+                            maxIndex = i;
+                        }
+                    }
+
+                    if (emotionIndex == maxIndex) {
+                        String label = mapToLabel(em);
+                        return new EmotionSummaryResponseDto(diary.getDate().toString(), label, diary.getSummary());
+                    } else {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
보호자 사용자 일별 일기 조회시, 매칭된 사용자 인지 검증 로직 추가

보호자 사용자 월별 + 감정 조회시, 날짜 + 감정 + 요약 정보 반환
요청 예시
<img width="1065" height="1213" alt="image" src="https://github.com/user-attachments/assets/4ea33cdf-542a-43b3-a7e0-b28327647a31" />
